### PR TITLE
Fixes `ReferenceError: yeti is not defined` if new is run with root

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -24,7 +24,7 @@ module.exports = function(args, options) {
 
   // 1. Stop if the process is being run as root
   if (isRoot()) {
-    yeti(messages.noRoot);
+    util.yeti(messages.noRoot);
     process.exit(1);
   }
 


### PR DESCRIPTION
See zurb/foundation-cli#8
